### PR TITLE
Add user agent spoofing

### DIFF
--- a/j/AK.py
+++ b/j/AK.py
@@ -113,6 +113,7 @@ def get_app_config():
         application_author = application_settings["application"].get("author")
         application_licence = application_settings["application"].get("license")
         application_url = application_settings["application"].get("url")
+        application_agent = application_settings["application"].get("user_agent")
 
         application_window_hint_type = application_settings["window"].get("hint_type")
         application_window_width = application_settings["window"].get("width")
@@ -135,6 +136,7 @@ def get_app_config():
                 application_author = \
                 application_licence = \
                 application_url = \
+                application_agent = \
                 application_window_full_screen = \
                 application_window_transparent = \
                 application_debug = \
@@ -154,6 +156,7 @@ def get_app_config():
                 application_author = \
                 application_licence = \
                 application_url = \
+                application_agent = \
                 application_window_hint_type = \
                 application_window_width = \
                 application_window_height = \
@@ -172,6 +175,7 @@ def get_app_config():
            application_author, \
            application_licence, \
            application_url, \
+           application_agent, \
            application_path, \
            application_window_hint_type, \
            application_window_width, \
@@ -195,6 +199,7 @@ class AppWindow(Gtk.Window):
         application_author, \
         application_licence, \
         application_url, \
+        application_agent, \
         application_path, \
         application_window_hint_type, \
         application_window_width, \
@@ -223,6 +228,10 @@ class AppWindow(Gtk.Window):
         self.webview = WebKit2.WebView.new_with_user_content_manager(self.manager)
 
         self.add(self.webview)
+        
+        if application_agent != "":
+          Webkit2.set_user_agent(application_agent)
+        
         self.settings = self.webview.get_settings()
 
         cookiesPath = '/tmp/cookies.txt'
@@ -363,6 +372,7 @@ class AppWindow(Gtk.Window):
         'author'       : '%(application_author)s',
         'license'      : '%(application_licence)s',
         'url'          : '%(application_url)s',
+        'user_agent'   : '%(application_agent)s',
         'windowWidth'  : '%(application_window_width)s',
         'windowHeight' : '%(application_window_height)s',
         'screenWidth'  : %(screen_width)s,

--- a/j/AK.py
+++ b/j/AK.py
@@ -229,10 +229,12 @@ class AppWindow(Gtk.Window):
 
         self.add(self.webview)
         
-        if application_agent != "":
-          Webkit2.set_user_agent(application_agent)
-        
         self.settings = self.webview.get_settings()
+        
+        if application_agent != "":
+            self.settings.set_user_agent(application_agent)
+            
+            print("Identifying as " + self.settings.get_user_agent())
 
         cookiesPath = '/tmp/cookies.txt'
         storage = WebKit2.CookiePersistentStorage.TEXT

--- a/j/AK.py
+++ b/j/AK.py
@@ -234,7 +234,7 @@ class AppWindow(Gtk.Window):
         if application_agent != "":
             self.settings.set_user_agent(application_agent)
             
-            print("Identifying as " + self.settings.get_user_agent())
+        print("Identifying as " + self.settings.get_user_agent())
 
         cookiesPath = '/tmp/cookies.txt'
         storage = WebKit2.CookiePersistentStorage.TEXT

--- a/template/application-settings.json
+++ b/template/application-settings.json
@@ -6,6 +6,7 @@
         "version": "a0.1",
         "author": "My Name",
         "url": "application url",
+        "user_agent": "",
         "license": "GPL"
     },
 


### PR DESCRIPTION
 ## Description of the changes proposed in the pull request

I wanted to implement user agent spoofing, because a web app that I tried wrapping gave me a "your browser is not supported" page. 

This is *NOT* currently working. I try to run `jak`, but I get an error saying that `application_agent is undefined`. I am not sure how to resolve this. I am new to Python and have only used it for data analysis so far. OO stuff is a little over my head still. 

I figured that, for now, I would throw this up here and perhaps someone with better knowledge of the language might be able to offer some pointers. 

In addition, I should admit that I am not even sure that the user agent will change, once I get past the "undefined" issue. But that is easier to play around with. 