### PR TITLE
Signify Python/Pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ cd Jade-Application-Kit
 
 Install using pip
 ```bash
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 or
 ```bash
-pip install Jade-Application-Kit
+pip3 install Jade-Application-Kit
 ```
 
 Install manually
 ```bash
-~/.virtualenv/python setup.py install
+~/.virtualenv/python3 setup.py install
 ```
 or
 ```bash


### PR DESCRIPTION
It is hard to demonstrate whether this is Python2  or Python3-besides the note, pip and python-as it may defaultly be 3 on Arch/Manjaro or whatever, on Debian based systems where both can be installed, this causes problems. This should clear up stuff.

 ## Reference to a related issue in your repository.


 ## Description of the changes proposed in the pull request
